### PR TITLE
Calibrate optimal_topic() to the published Test 1 (v0.9.9)

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -36,18 +36,37 @@ the `optimal-topic-core` branch, and what is deliberately deferred.
   identifier (a `doc_map` index vector passed to the C++ core), and the core
   stops if the mapping points past the rows of `@gamma`.
 
-### Confirmed, deliberately unchanged (methodological — author's call)
+### Resolved in 0.9.9 — calibrated to the published test (Test 1, Eq. 8)
 
-- **`pchisq(stat, df = 1, lower.tail = TRUE)`.** A goodness-of-fit p-value is
-  conventionally the upper tail. With the lower tail, a *small* statistic
-  yields a *small* p-value, which interacts with the `alpha` selection rule
-  ("first model with p-value ≤ alpha"). This is tied to the paper's selection
-  procedure and is left exactly as is; the test suite encodes the current
-  behavior.
-- **`round(val * 1e4) / 1e4 > q` cumulative-mass cutoff.** Rounding to 4
-  decimals before comparing with `q` makes the truncation index unstable near
-  ties (documents whose cumulative mass sits within 5e-5 of `q` can flip).
-  Kept verbatim to preserve numerical output.
+Reading the JMLR paper (Lewis & Grossetti 2022, 23(58)) settled both flags and
+uncovered three more deviations; all five are fixed on the `test-calibration`
+branch, with the old pipeline frozen behind `selection = "legacy"`
+(deprecated, bit-identical to v0.9.8, removal before v1.0.0):
+
+- **Tail and df.** The paper claims `OpTop ~ χ²` with `df = Σ_j P_j` and
+  frames adequacy as "unable to reject" — an upper-tail test on the *raw*
+  statistic. The code used the lower tail with `df = 1` on the *standardized*
+  statistic. Now: `pchisq(raw, df = Σ P_j, lower.tail = FALSE)`; the reported
+  `OpTop` column stays standardized (`raw / df`, the paper's Figure 2 scale).
+- **Selection.** The paper selects the global minimum of the standardized
+  statistic and never uses p-values for selection; the old "first
+  `pval ≤ alpha`" lower-tail rule was an implementation-era invention. Now:
+  `selection = c("sequential", "min", "legacy")` — the default sequential
+  adequacy scan (smallest K with `pval > alpha`, global-minimum fallback),
+  the paper's `"min"`, and the frozen legacy rule.
+- **Per-document scaling.** Eq. (8) scales each document's Pearson term by
+  `(P_j + 1)` (the number of bins); the code used `P_j`.
+- **Cutoff.** Footnote 5 collapses the least-probable words with total mass
+  strictly below `I^K = 0.05`; the code rounded the cumulative mass to 4
+  decimals, put the crossing word in the tail (collapsed mass *exceeding*
+  `1 − q`), and defaulted to `q = 0.80`. Now: exact comparison, crossing word
+  kept, default `q = 0.95 = 1 − I^K`.
+- **Calibration caveat (documented, not "fixed").** With `df = Σ P_j` in the
+  thousands, χ² p-values saturate near 0/1 unless the fit is genuinely
+  borderline; when the sequential rule degenerates, the minimum of the
+  standardized curve carries the information — which is why the paper's case
+  study uses the min rule. Establishing a sharper null law (asymptotics or
+  simulation calibration) remains future methodological work for the paper.
 
 ## Deferred
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: OpTop
 Type: Package
 Title: Optimal Topic Selection and Goodness-of-Fit for LDA Models
-Version: 0.9.8
+Version: 0.9.9
 Authors@R: c( 
     person("Francesco", "Grossetti", email = "francesco.grossetti@unibocconi.it", 
     role = c("cre", "aut", "cph"), comment = c(ORCID = "0000-0002-5130-7745")), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,35 @@
+# OpTop 0.9.9
+
+### Major Changes — `optimal_topic()` calibrated to the published test
+
+**This release changes numerical results.** The implementation is now faithful to
+Test 1 (Equation 8) of Lewis and Grossetti (2022):
+
+* **Statistic**: each document's Pearson term is scaled by `P_j + 1` (the number of bins,
+  previously `P_j`), and the corpus statistic is chi-square with `df = sum_j P_j`. The
+  returned `OpTop` column reports the standardized statistic (raw / `df`, the scale of the
+  paper's Figure 2) and the table gains a `df` column.
+
+* **P-values**: upper tail of the raw statistic on its full degrees of freedom
+  (previously: lower tail of the standardized statistic on 1 df, which asked "is the fit
+  suspiciously perfect?" rather than "does the model fit?").
+
+* **Selection rules**: new `selection` argument — `"sequential"` (default; smallest `K` the
+  test fails to reject at `alpha`, with a warned fallback to the global minimum),
+  `"min"` (the global minimum of the standardized statistic — the rule used in the paper's
+  case study), and `"legacy"` (the frozen pre-0.9.9 pipeline, bit-identical to v0.9.8).
+  `"legacy"` is deprecated at birth and will be removed before v1.0.0.
+
+* **Cutoff**: the "relatively important" words are now the smallest sorted head whose
+  cumulative mass strictly exceeds `q`, keeping the crossing word, so the collapsed tail
+  stays strictly below `1 - q` (the paper's footnote 5); the 4-decimal rounding hack is
+  gone. The default `q` moves from `0.80` to `0.95`, matching the paper's numerical
+  setting `I^K = 0.05`.
+
+* Documentation now includes an honest calibration caveat: with `df = sum_j P_j` in the
+  thousands the chi-square p-values saturate near 0/1 unless the fit is borderline, in
+  which case the shape and minimum of the standardized curve carry the information.
+
 # OpTop 0.9.8
 
 ### Major Changes

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2,8 +2,8 @@
 # Generator token: 10BE3573-1514-4C36-9D1C-5A225CD40393
 
 #' @keywords internal
-optimal_topic_core <- function(lda_models, weighted_dfm, q, doc_map) {
-    .Call(`_OpTop_optimal_topic_core`, lda_models, weighted_dfm, q, doc_map)
+optimal_topic_core <- function(lda_models, weighted_dfm, q, doc_map, legacy) {
+    .Call(`_OpTop_optimal_topic_core`, lda_models, weighted_dfm, q, doc_map, legacy)
 }
 
 #' @keywords internal

--- a/R/optimal_topic.R
+++ b/R/optimal_topic.R
@@ -5,41 +5,69 @@ if ( getRversion() >= "2.15.1" ) {
                              ".", "chisquare", "chisquare_mod",
                              "row_cut", "chi_sum", "word_prop_hat",
                              "word_prop_hat_cum", "pval", "docid",
-                             "OpTop") )
+                             "OpTop", "raw", "df") )
 }
 #' Find the optimal number of topics from a pool of LDA models
 #'
-#' Identify the number of topics that best describes the corpus by applying a
-#' fast chi-square–style test across a grid of `topicmodels::LDA` fits. The
-#' routine evaluates each model and selects the optimal topic count using a
-#' significance rule controlled by `alpha`, with a fallback to the global
-#' minimum of the statistic.
+#' Identify the number of topics that best describes the corpus with the
+#' Test 1 statistic of Lewis and Grossetti (2022), a Pearson chi-square
+#' goodness-of-fit test on each document's word distribution. The routine
+#' evaluates each model of the grid and selects the optimal topic count with
+#' one of three rules; see Details.
 #'
 #' @param lda_models A list of `topicmodels::LDA` objects (VEM), ordered by
 #'   increasing number of topics. The grid should span the candidate values of `K`.
 #' @param weighted_dfm A weighted `quanteda::dfm` containing word proportions
 #'   for each document; it is recommended that document ids are available via
 #'   `quanteda::docid()`.
-#' @param q Numeric in `(0, 1]`. Cumulative mass used to define the truncated
-#'   envelope (default `0.80`).
-#' @param alpha Numeric in `[0, 1]`. Significance level for the selection rule
-#'   (default `0.05`). See Details.
-#' @param do_plot Logical; if `TRUE`, plot the statistic versus topics with
-#'   vertical and horizontal guides at the selected optimum (default `TRUE`).
+#' @param q Numeric in `(0, 1]`. Cumulative probability mass retained as
+#'   "relatively important" words; the remaining words are collapsed into a
+#'   single bin whose mass stays strictly below `1 - q`. Equals `1 - I^K` in
+#'   the paper's notation; the default `0.95` matches the paper's numerical
+#'   setting `I^K = 0.05`.
+#' @param alpha Numeric in `[0, 1]`. Significance level used by the
+#'   `"sequential"` and `"legacy"` selection rules (default `0.05`); ignored
+#'   by `"min"`.
+#' @param selection Character; how the optimal `K` is chosen (see Details):
+#'   `"sequential"` (default), `"min"`, or `"legacy"` (deprecated).
+#' @param do_plot Logical; if `TRUE`, plot the standardized statistic versus
+#'   topics with vertical and horizontal guides at the selected optimum
+#'   (default `TRUE`).
 #' @param verbose Logical; if `TRUE`, report progress (a `cli` progress bar
 #'   across the model grid) and a selection summary (default `FALSE`).
-#'   Regardless of `verbose`, dropping documents that the models never saw is
-#'   always signalled with a warning.
+#'   Regardless of `verbose`, dropping documents that the models never saw
+#'   and the sequential rule's fallback are always signalled.
 #'
 #' @details
-#' The method builds a Pearson-type statistic under a multinomial view of word
-#' counts and evaluates stability for each candidate `K`. The envelope used in
-#' the comparison is truncated at cumulative mass `q` (e.g., `q = 0.80` keeps
-#' the top 80% of mass).
+#' For each document, the fitted word probabilities are sorted in decreasing
+#' order and the smallest head whose cumulative mass exceeds `q` is kept
+#' (`P_j` words); the remaining words are collapsed into a single "min" bin.
+#' The document contributes `(P_j + 1)` times its Pearson term over the
+#' `P_j + 1` bins, and the corpus statistic is the sum over documents
+#' (Equation 8 of the paper), asymptotically chi-square with
+#' `df = sum_j P_j` degrees of freedom. The returned `OpTop` column reports
+#' the *standardized* statistic (raw statistic divided by `df`, the version
+#' plotted in the paper's Figure 2), while `pval` is the upper-tail p-value
+#' of the raw statistic on its full degrees of freedom.
 #'
-#' **Selection rule.** The optimal `K` is the first model whose p-value is at
-#' most `alpha`. If no model reaches `alpha`, the model with the minimum
-#' statistic is selected. Setting `alpha = 0` forces the global-minimum rule.
+#' **Selection rules.**
+#' - `"sequential"` (default): scan `K` upward and select the smallest `K`
+#'   the test fails to reject (`pval > alpha`) — the classical sequential
+#'   scheme for model order. If every model is rejected, the rule falls back
+#'   to the global minimum with a warning.
+#' - `"min"`: select the `K` with the minimum standardized statistic — the
+#'   rule used in the published case study.
+#' - `"legacy"`: reproduce the pre-0.9.9 behavior exactly (rounded cutoff
+#'   with the crossing word collapsed, `P_j` scaling, lower-tail p-value with
+#'   1 degree of freedom, "first `pval <= alpha`" rule). Deprecated; it will
+#'   be removed before v1.0.0.
+#'
+#' **A calibration caveat.** With `df = sum_j P_j` in the thousands, the
+#' chi-square reference distribution is extremely concentrated, so upper-tail
+#' p-values tend to saturate at 0 or 1 unless the fit is genuinely borderline.
+#' When the sequential rule degenerates (all 0 or all 1), the shape of the
+#' standardized statistic — and its minimum — carries the information, which
+#' is why the paper's case study uses the `"min"` rule.
 #'
 #' **Input alignment.** `weighted_dfm` must be a `quanteda::dfm` of word
 #' proportions (row-wise). Document identifiers are taken from
@@ -54,25 +82,34 @@ if ( getRversion() >= "2.15.1" ) {
 #'
 #' @return A `data.table` with columns:
 #' - `topic`: integer number of topics (`K`).
-#' - `OpTop`: standardized chi-square–style statistic for each `K`.
-#' - `pval`: p-value associated with `OpTop`.
+#' - `OpTop`: standardized Test 1 statistic (raw statistic / `df`).
+#' - `df`: degrees of freedom `sum_j P_j` of the raw statistic.
+#' - `pval`: p-value associated with the raw statistic (upper tail for
+#'   `"sequential"`/`"min"`; the legacy lower-tail value for `"legacy"`).
 #'
 #' @examples
 #' \dontrun{
 #' # Compute word proportions from a corpus objects
 #' test1 <- optimal_topic( lda_models = lda_list,
 #'                         weighted_dfm = weighted_dfm,
-#'                         q = 0.80,
+#'                         q = 0.95,
 #'                         alpha = 0.05,
+#'                         selection = "sequential",
 #'                         verbose = TRUE )
 #' }
+#'
+#' @references
+#' Lewis, C. M. and Grossetti, F. (2022). A statistical approach for optimal
+#' topic model identification. *Journal of Machine Learning Research*,
+#' 23(58), 1--20. <https://jmlr.org/papers/v23/19-297.html>
 #'
 #' @seealso [topicmodels::LDA()]
 #'
 #' @import data.table
 #' @export
 
-optimal_topic <- function( lda_models, weighted_dfm, q = 0.80, alpha = 0.05,
+optimal_topic <- function( lda_models, weighted_dfm, q = 0.95, alpha = 0.05,
+                           selection = c( "sequential", "min", "legacy" ),
                            do_plot = TRUE, verbose = FALSE ) {
 
   if ( !is.list( lda_models ) ) {
@@ -96,8 +133,19 @@ optimal_topic <- function( lda_models, weighted_dfm, q = 0.80, alpha = 0.05,
   if ( !is.numeric( alpha ) ) {
     stop( "alpha must be a numeric" )
   }
+  selection <- match.arg( selection )
   if ( !is.logical( verbose ) ) {
     stop( "verbose must be either TRUE or FALSE" )
+  }
+
+  if ( selection == "legacy" ) {
+    lifecycle::deprecate_warn(
+      when = "0.9.9",
+      what = I( 'optimal_topic(selection = "legacy")' ),
+      details = paste( "The legacy rule (lower-tail p-value with 1 degree of",
+                       "freedom) predates the calibration to the published",
+                       "test and will be removed before v1.0.0." )
+    )
   }
 
   tic <- proc.time()
@@ -131,15 +179,18 @@ optimal_topic <- function( lda_models, weighted_dfm, q = 0.80, alpha = 0.05,
   if ( verbose ) {
     cli::cli_alert_info( paste(
       "Evaluating {n_models} models on {length(docs)} document{?s} and",
-      "{quanteda::nfeat(weighted_dfm)} features (q = {q}, alpha = {alpha})"
+      "{quanteda::nfeat(weighted_dfm)} features (q = {q}, alpha = {alpha},",
+      "selection = {selection})"
     ) )
     cli::cli_progress_bar( "Processing LDA grid", total = n_models )
   }
 
+  legacy <- selection == "legacy"
   Chi_K_rows <- vector( "list", n_models )
   for ( i_mod in seq_len( n_models ) ) {
     Chi_K_rows[[ i_mod ]] <- optimal_topic_core( lda_models[ i_mod ],
-                                                 weighted_dfm, q, doc_map )
+                                                 weighted_dfm, q, doc_map,
+                                                 legacy )
     if ( verbose ) {
       cli::cli_progress_update(
         status = paste0( "k = ", lda_models[[ i_mod ]]@k )
@@ -151,19 +202,49 @@ optimal_topic <- function( lda_models, weighted_dfm, q = 0.80, alpha = 0.05,
   }
 
   Chi_K <- data.table::as.data.table( do.call( rbind, Chi_K_rows ) )
-  data.table::setnames( Chi_K, old = names( Chi_K ), c( "topic", "OpTop", "pval" ) )
+  data.table::setnames( Chi_K, old = names( Chi_K ), c( "topic", "raw", "df" ) )
+  Chi_K[ , OpTop := raw / df ]
+  if ( legacy ) {
+    # pre-0.9.9 convention: lower tail of the standardized statistic on 1 df
+    Chi_K[ , pval := stats::pchisq( OpTop, df = 1L, lower.tail = TRUE ) ]
+  } else {
+    # Eq. (8): the raw statistic is chi-square with df = sum_j P_j under
+    # adequacy, and misspecification only inflates it, so the p-value is the
+    # upper tail
+    Chi_K[ , pval := stats::pchisq( raw, df = df, lower.tail = FALSE ) ]
+  }
+  Chi_K[ , raw := NULL ]
+  data.table::setcolorder( Chi_K, c( "topic", "OpTop", "df", "pval" ) )
 
   global_min <- Chi_K[ , .SD[ which.min( OpTop ) ] ]
-  alpha_min <- Chi_K[ pval <= alpha ][ 1L ]
-  if ( alpha == 0 || all( is.na( alpha_min ) ) ) {
+  if ( selection == "sequential" ) {
+    accepted <- Chi_K[ pval > alpha ][ 1L ]
+    if ( all( is.na( accepted ) ) ) {
+      cli::cli_alert_warning( paste(
+        "No model passes the adequacy test at alpha = {alpha};",
+        "falling back to the global minimum"
+      ) )
+      best_topic <- global_min
+      rule <- "global minimum (sequential fallback)"
+    } else {
+      best_topic <- accepted
+      rule <- paste0( "sequential adequacy scan at alpha = ", alpha )
+    }
+  } else if ( selection == "min" ) {
     best_topic <- global_min
     rule <- "global minimum"
-  } else if ( global_min$topic > alpha_min$topic ) {
-    best_topic <- alpha_min
-    rule <- paste0( "significance level of ", alpha )
   } else {
-    best_topic <- global_min
-    rule <- "global minimum"
+    alpha_min <- Chi_K[ pval <= alpha ][ 1L ]
+    if ( alpha == 0 || all( is.na( alpha_min ) ) ) {
+      best_topic <- global_min
+      rule <- "global minimum (legacy)"
+    } else if ( global_min$topic > alpha_min$topic ) {
+      best_topic <- alpha_min
+      rule <- paste0( "legacy significance level of ", alpha )
+    } else {
+      best_topic <- global_min
+      rule <- "global minimum (legacy)"
+    }
   }
   if ( verbose ) {
     cli::cli_alert_success(

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![lifecycle](https://lifecycle.r-lib.org/articles/figures/lifecycle-experimental.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 [![R-CMD-check](https://github.com/contefranz/OpTop/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/contefranz/OpTop/actions/workflows/R-CMD-check.yaml)
 [![codecov](https://codecov.io/gh/contefranz/OpTop/graph/badge.svg)](https://app.codecov.io/gh/contefranz/OpTop)
-[![release](https://img.shields.io/badge/release-v0.9.8-blue.svg)](https://github.com/contefranz/OpTop/releases/tag/v0.9.8)
+[![release](https://img.shields.io/badge/release-v0.9.9-blue.svg)](https://github.com/contefranz/OpTop/releases/tag/v0.9.9)
 [![license](https://img.shields.io/badge/license-GPL--3-blue.svg)](https://en.wikipedia.org/wiki/GNU_General_Public_License)
 
 # OpTop
@@ -95,11 +95,13 @@ VEM_models <- lapply(
   }
 ) 
 
-# 3) Choose the optimal K (verbose = TRUE reports progress and the selection)
+# 3) Choose the optimal K (selection: "sequential" adequacy scan by default,
+#    "min" for the paper's global-minimum rule; verbose = TRUE reports progress)
 res_opt   <- optimal_topic(lda_models = VEM_models, 
                            weighted_dfm = weighted_dfm,
-                           q = 0.80, 
+                           q = 0.95, 
                            alpha = 0.05, 
+                           selection = "sequential",
                            do_plot = TRUE,
                            verbose = TRUE)
 

--- a/man/optimal_topic.Rd
+++ b/man/optimal_topic.Rd
@@ -7,8 +7,9 @@
 optimal_topic(
   lda_models,
   weighted_dfm,
-  q = 0.8,
+  q = 0.95,
   alpha = 0.05,
+  selection = c("sequential", "min", "legacy"),
   do_plot = TRUE,
   verbose = FALSE
 )
@@ -21,44 +22,77 @@ increasing number of topics. The grid should span the candidate values of \code{
 for each document; it is recommended that document ids are available via
 \code{quanteda::docid()}.}
 
-\item{q}{Numeric in \verb{(0, 1]}. Cumulative mass used to define the truncated
-envelope (default \code{0.80}).}
+\item{q}{Numeric in \verb{(0, 1]}. Cumulative probability mass retained as
+"relatively important" words; the remaining words are collapsed into a
+single bin whose mass stays strictly below \code{1 - q}. Equals \code{1 - I^K} in
+the paper's notation; the default \code{0.95} matches the paper's numerical
+setting \code{I^K = 0.05}.}
 
-\item{alpha}{Numeric in \verb{[0, 1]}. Significance level for the selection rule
-(default \code{0.05}). See Details.}
+\item{alpha}{Numeric in \verb{[0, 1]}. Significance level used by the
+\code{"sequential"} and \code{"legacy"} selection rules (default \code{0.05}); ignored
+by \code{"min"}.}
 
-\item{do_plot}{Logical; if \code{TRUE}, plot the statistic versus topics with
-vertical and horizontal guides at the selected optimum (default \code{TRUE}).}
+\item{selection}{Character; how the optimal \code{K} is chosen (see Details):
+\code{"sequential"} (default), \code{"min"}, or \code{"legacy"} (deprecated).}
+
+\item{do_plot}{Logical; if \code{TRUE}, plot the standardized statistic versus
+topics with vertical and horizontal guides at the selected optimum
+(default \code{TRUE}).}
 
 \item{verbose}{Logical; if \code{TRUE}, report progress (a \code{cli} progress bar
 across the model grid) and a selection summary (default \code{FALSE}).
-Regardless of \code{verbose}, dropping documents that the models never saw is
-always signalled with a warning.}
+Regardless of \code{verbose}, dropping documents that the models never saw
+and the sequential rule's fallback are always signalled.}
 }
 \value{
 A \code{data.table} with columns:
 \itemize{
 \item \code{topic}: integer number of topics (\code{K}).
-\item \code{OpTop}: standardized chi-square–style statistic for each \code{K}.
-\item \code{pval}: p-value associated with \code{OpTop}.
+\item \code{OpTop}: standardized Test 1 statistic (raw statistic / \code{df}).
+\item \code{df}: degrees of freedom \verb{sum_j P_j} of the raw statistic.
+\item \code{pval}: p-value associated with the raw statistic (upper tail for
+\code{"sequential"}/\code{"min"}; the legacy lower-tail value for \code{"legacy"}).
 }
 }
 \description{
-Identify the number of topics that best describes the corpus by applying a
-fast chi-square–style test across a grid of \code{topicmodels::LDA} fits. The
-routine evaluates each model and selects the optimal topic count using a
-significance rule controlled by \code{alpha}, with a fallback to the global
-minimum of the statistic.
+Identify the number of topics that best describes the corpus with the
+Test 1 statistic of Lewis and Grossetti (2022), a Pearson chi-square
+goodness-of-fit test on each document's word distribution. The routine
+evaluates each model of the grid and selects the optimal topic count with
+one of three rules; see Details.
 }
 \details{
-The method builds a Pearson-type statistic under a multinomial view of word
-counts and evaluates stability for each candidate \code{K}. The envelope used in
-the comparison is truncated at cumulative mass \code{q} (e.g., \code{q = 0.80} keeps
-the top 80\% of mass).
+For each document, the fitted word probabilities are sorted in decreasing
+order and the smallest head whose cumulative mass exceeds \code{q} is kept
+(\code{P_j} words); the remaining words are collapsed into a single "min" bin.
+The document contributes \code{(P_j + 1)} times its Pearson term over the
+\code{P_j + 1} bins, and the corpus statistic is the sum over documents
+(Equation 8 of the paper), asymptotically chi-square with
+\verb{df = sum_j P_j} degrees of freedom. The returned \code{OpTop} column reports
+the \emph{standardized} statistic (raw statistic divided by \code{df}, the version
+plotted in the paper's Figure 2), while \code{pval} is the upper-tail p-value
+of the raw statistic on its full degrees of freedom.
 
-\strong{Selection rule.} The optimal \code{K} is the first model whose p-value is at
-most \code{alpha}. If no model reaches \code{alpha}, the model with the minimum
-statistic is selected. Setting \code{alpha = 0} forces the global-minimum rule.
+\strong{Selection rules.}
+\itemize{
+\item \code{"sequential"} (default): scan \code{K} upward and select the smallest \code{K}
+the test fails to reject (\code{pval > alpha}) — the classical sequential
+scheme for model order. If every model is rejected, the rule falls back
+to the global minimum with a warning.
+\item \code{"min"}: select the \code{K} with the minimum standardized statistic — the
+rule used in the published case study.
+\item \code{"legacy"}: reproduce the pre-0.9.9 behavior exactly (rounded cutoff
+with the crossing word collapsed, \code{P_j} scaling, lower-tail p-value with
+1 degree of freedom, "first \code{pval <= alpha}" rule). Deprecated; it will
+be removed before v1.0.0.
+}
+
+\strong{A calibration caveat.} With \verb{df = sum_j P_j} in the thousands, the
+chi-square reference distribution is extremely concentrated, so upper-tail
+p-values tend to saturate at 0 or 1 unless the fit is genuinely borderline.
+When the sequential rule degenerates (all 0 or all 1), the shape of the
+standardized statistic — and its minimum — carries the information, which
+is why the paper's case study uses the \code{"min"} rule.
 
 \strong{Input alignment.} \code{weighted_dfm} must be a \code{quanteda::dfm} of word
 proportions (row-wise). Document identifiers are taken from
@@ -76,11 +110,17 @@ to handle high-dimensional vocabularies efficiently.
 # Compute word proportions from a corpus objects
 test1 <- optimal_topic( lda_models = lda_list,
                         weighted_dfm = weighted_dfm,
-                        q = 0.80,
+                        q = 0.95,
                         alpha = 0.05,
+                        selection = "sequential",
                         verbose = TRUE )
 }
 
+}
+\references{
+Lewis, C. M. and Grossetti, F. (2022). A statistical approach for optimal
+topic model identification. \emph{Journal of Machine Learning Research},
+23(58), 1--20. \url{https://jmlr.org/papers/v23/19-297.html}
 }
 \seealso{
 \code{\link[topicmodels:LDA]{topicmodels::LDA()}}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -12,8 +12,8 @@ Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
 #endif
 
 // optimal_topic_core
-arma::mat optimal_topic_core(const Rcpp::List& lda_models, const arma::sp_mat& weighted_dfm, double q, const arma::uvec& doc_map);
-RcppExport SEXP _OpTop_optimal_topic_core(SEXP lda_modelsSEXP, SEXP weighted_dfmSEXP, SEXP qSEXP, SEXP doc_mapSEXP) {
+arma::mat optimal_topic_core(const Rcpp::List& lda_models, const arma::sp_mat& weighted_dfm, double q, const arma::uvec& doc_map, bool legacy);
+RcppExport SEXP _OpTop_optimal_topic_core(SEXP lda_modelsSEXP, SEXP weighted_dfmSEXP, SEXP qSEXP, SEXP doc_mapSEXP, SEXP legacySEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -21,7 +21,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const arma::sp_mat& >::type weighted_dfm(weighted_dfmSEXP);
     Rcpp::traits::input_parameter< double >::type q(qSEXP);
     Rcpp::traits::input_parameter< const arma::uvec& >::type doc_map(doc_mapSEXP);
-    rcpp_result_gen = Rcpp::wrap(optimal_topic_core(lda_models, weighted_dfm, q, doc_map));
+    Rcpp::traits::input_parameter< bool >::type legacy(legacySEXP);
+    rcpp_result_gen = Rcpp::wrap(optimal_topic_core(lda_models, weighted_dfm, q, doc_map, legacy));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -52,7 +53,7 @@ END_RCPP
 }
 
 static const R_CallMethodDef CallEntries[] = {
-    {"_OpTop_optimal_topic_core", (DL_FUNC) &_OpTop_optimal_topic_core, 4},
+    {"_OpTop_optimal_topic_core", (DL_FUNC) &_OpTop_optimal_topic_core, 5},
     {"_OpTop_topic_match_core", (DL_FUNC) &_OpTop_topic_match_core, 4},
     {"_OpTop_normalize_columns", (DL_FUNC) &_OpTop_normalize_columns, 1},
     {NULL, NULL, 0}

--- a/src/optimal_topic_core.cpp
+++ b/src/optimal_topic_core.cpp
@@ -6,7 +6,8 @@
 arma::mat optimal_topic_core(const Rcpp::List& lda_models,
                              const arma::sp_mat& weighted_dfm,
                              double q,
-                             const arma::uvec& doc_map)
+                             const arma::uvec& doc_map,
+                             bool legacy)
 {
     const arma::uword n_models = lda_models.size();
     const arma::uword n_docs = weighted_dfm.n_rows;
@@ -21,9 +22,11 @@ arma::mat optimal_topic_core(const Rcpp::List& lda_models,
     // instead of element-by-element sparse row reads
     const arma::sp_mat dfm_t = weighted_dfm.t();
 
-    // this is the output of this method: one row per model with the number of
-    // topics (the "topic" column consumed by the caller), the standardized
-    // chi-square statistic and its p-value
+    // output: one row per model with the number of topics (the "topic" column
+    // consumed by the caller), the raw Test 1 statistic of Eq. (8) in Lewis &
+    // Grossetti (2022), and its degrees of freedom sum_j P_j; standardization
+    // and p-values are computed by the R caller, where the tail convention is
+    // visible and testable
     arma::mat Chi_K(n_models, 3);
 
     const arma::uword max_gamma_row = doc_map.max();
@@ -46,7 +49,7 @@ arma::mat optimal_topic_core(const Rcpp::List& lda_models,
         }
 
         double sum_chi = 0.0;
-        double sum_icut = 0.0;
+        double sum_df = 0.0;
 
         for (arma::uword block_start = 0; block_start < n_docs; block_start += block_size)
         {
@@ -70,34 +73,60 @@ arma::mat optimal_topic_core(const Rcpp::List& lda_models,
                 arma::vec X_cumsum = arma::cumsum(X);
                 weighted_dfm_j_doc = weighted_dfm_j_doc(sort_indices);
 
-                // find elements with estimated probability lower than quantile
-                auto first_greater_than_q = std::find_if(X_cumsum.begin(),
-                                                         X_cumsum.end(),
-                                                         [&q](double val) {return round(val * 1e4) / 1e4 > q;});
-                std::size_t icut = std::distance(X_cumsum.begin(), first_greater_than_q);
-                std::size_t n_cut_elements = X.size() - icut;
+                if (legacy) {
+                    // 0.9.8 arithmetic, kept verbatim for reproducibility of
+                    // pre-calibration results: rounded cutoff, crossing word
+                    // collapsed into the tail, per-document multiplier P_j
+                    auto first_greater_than_q = std::find_if(X_cumsum.begin(),
+                                                             X_cumsum.end(),
+                                                             [&q](double val) {return round(val * 1e4) / 1e4 > q;});
+                    std::size_t icut = std::distance(X_cumsum.begin(), first_greater_than_q);
+                    std::size_t n_cut_elements = X.size() - icut;
 
-                // Pearson terms on the kept elements plus one pooled term for
-                // the truncated tail
-                const arma::vec head_diff = weighted_dfm_j_doc.head(icut) - X.head(icut);
-                const double tail_X = arma::sum(X.tail(n_cut_elements));
-                const double tail_diff = arma::sum(weighted_dfm_j_doc.tail(n_cut_elements)) - tail_X;
-                const double chi_sq_fit = icut * (
-                    arma::sum(head_diff % head_diff / X.head(icut))
-                    +
-                    tail_diff * tail_diff / tail_X
-                );
+                    const arma::vec head_diff = weighted_dfm_j_doc.head(icut) - X.head(icut);
+                    const double tail_X = arma::sum(X.tail(n_cut_elements));
+                    const double tail_diff = arma::sum(weighted_dfm_j_doc.tail(n_cut_elements)) - tail_X;
+                    const double pearson = arma::sum(head_diff % head_diff / X.head(icut))
+                                           + tail_diff * tail_diff / tail_X;
 
-                sum_chi += chi_sq_fit;
-                sum_icut += double(icut);
+                    sum_chi += double(icut) * pearson;
+                    sum_df += double(icut);
+                } else {
+                    // Eq. (8): the P_j important words are the smallest head
+                    // whose cumulative mass strictly exceeds q = 1 - I^K (the
+                    // crossing word is kept, so the collapsed tail keeps mass
+                    // strictly below I^K, cf. footnote 5), and the document
+                    // contributes (bins) * Pearson with df = bins - 1, where
+                    // bins = P_j + 1 with the collapsed min bin
+                    auto first_greater_than_q = std::find_if(X_cumsum.begin(),
+                                                             X_cumsum.end(),
+                                                             [&q](double val) {return val > q;});
+                    const std::size_t p_j = (first_greater_than_q == X_cumsum.end())
+                        ? X.n_elem
+                        : std::distance(X_cumsum.begin(), first_greater_than_q) + 1;
+                    const std::size_t n_tail = X.n_elem - p_j;
+
+                    const arma::vec head_diff = weighted_dfm_j_doc.head(p_j) - X.head(p_j);
+                    double pearson = arma::sum(head_diff % head_diff / X.head(p_j));
+
+                    std::size_t n_bins = p_j;
+                    if (n_tail > 0) {
+                        const double tail_X = arma::sum(X.tail(n_tail));
+                        const double tail_diff = arma::sum(weighted_dfm_j_doc.tail(n_tail)) - tail_X;
+                        pearson += tail_diff * tail_diff / tail_X;
+                        n_bins += 1;
+                    }
+
+                    sum_chi += double(n_bins) * pearson;
+                    sum_df += double(n_bins - 1);
+                }
             }
         }
 
-        const double stat = sum_chi / sum_icut;
         Chi_K.row(i_mod) = arma::rowvec({
             double(current_k),
-            stat,
-            R::pchisq(stat, 1, true, false)
+            sum_chi,
+            sum_df
         });
     }
 

--- a/tests/testthat/helper-reference.R
+++ b/tests/testthat/helper-reference.R
@@ -147,19 +147,18 @@ ref_index_word <- function(model, dtm, partition, baseline,
        K = tp$K, metric = metric)
 }
 
-# Naive reference for optimal_topic(). Mirrors the semantics of
-# src/optimal_topic_core.cpp verbatim, one explicit loop per document:
+# Naive LEGACY reference for optimal_topic(selection = "legacy"). Mirrors the
+# pre-0.9.9 semantics verbatim, one explicit loop per document:
 # X_j = gamma_j %*% exp(beta), sorted descending; the envelope is truncated at
 # the first position whose cumulative mass, rounded half-away-from-zero to 4
-# decimals (std::round), exceeds q; the truncated tail is pooled into a single
-# bin; chi_j = icut * (sum((o - e)^2 / e) + pooled term). Per model the
+# decimals (std::round), exceeds q, with the crossing word collapsed into the
+# tail; chi_j = icut * (sum((o - e)^2 / e) + pooled term). Per model the
 # statistic is sum(chi_j) / sum(icut_j) and the p-value is the LOWER tail of a
-# chi-square with 1 df (a documented oddity preserved on purpose — see
-# AUDIT.md).
+# chi-square with 1 df.
 #
 # `W_prop` is a plain dense matrix of row-wise word proportions whose rows and
 # columns are aligned with the models, exactly as the C++ core assumes.
-ref_optimal_topic <- function(models, W_prop, q = 0.80) {
+ref_optimal_topic_legacy <- function(models, W_prop, q = 0.80) {
   out <- lapply(models, function(m) {
     dtw <- m@gamma                 # J x K
     tww <- t(exp(m@beta))          # W x K
@@ -190,8 +189,60 @@ ref_optimal_topic <- function(models, W_prop, q = 0.80) {
     }
 
     stat <- sum(chi) / sum(icut)
-    c(topic = ncol(dtw), OpTop = stat,
+    c(topic = ncol(dtw), OpTop = stat, df = sum(icut),
       pval = stats::pchisq(stat, df = 1, lower.tail = TRUE))
+  })
+  as.data.frame(do.call(rbind, out))
+}
+
+# Naive reference for the calibrated Test 1 of Lewis & Grossetti (2022),
+# Eq. (8): per document, the P_j important words are the smallest
+# descending-sorted head whose cumulative mass strictly exceeds q (the
+# crossing word is KEPT, so the collapsed tail keeps mass < 1 - q, footnote
+# 5); the document contributes (P_j + 1) * Pearson over the P_j + 1 bins with
+# P_j degrees of freedom (bins - 1; if the tail is empty the min bin is
+# dropped, the multiplier is P_j and the df is P_j - 1). The corpus statistic
+# is the RAW sum over documents, chi-square with df = sum_j P_j, and the
+# p-value is the UPPER tail. The reported OpTop is the standardized statistic
+# raw / df, the quantity plotted in the paper's Figure 2.
+ref_optimal_topic <- function(models, W_prop, q = 0.95) {
+  out <- lapply(models, function(m) {
+    dtw <- m@gamma                 # J x K
+    tww <- t(exp(m@beta))          # W x K
+    J <- nrow(W_prop)
+
+    chi <- numeric(J)
+    dfs <- numeric(J)
+    for (j in seq_len(J)) {
+      X <- drop(tww %*% dtw[j, ])
+      o <- W_prop[j, ]
+
+      ord <- order(X, decreasing = TRUE)
+      X <- X[ord]
+      o <- o[ord]
+
+      cum <- cumsum(X)
+      above <- which(cum > q)
+      p_j <- if (length(above)) above[1] else length(X)
+
+      head_idx <- seq_len(p_j)
+      pearson <- sum((o[head_idx] - X[head_idx])^2 / X[head_idx])
+      n_bins <- p_j
+      if (p_j < length(X)) {
+        o_tail <- sum(o[-head_idx])
+        X_tail <- sum(X[-head_idx])
+        pearson <- pearson + (o_tail - X_tail)^2 / X_tail
+        n_bins <- p_j + 1L
+      }
+
+      chi[j] <- n_bins * pearson
+      dfs[j] <- n_bins - 1L
+    }
+
+    raw <- sum(chi)
+    df <- sum(dfs)
+    c(topic = ncol(dtw), OpTop = raw / df, df = df,
+      pval = stats::pchisq(raw, df = df, lower.tail = FALSE))
   })
   as.data.frame(do.call(rbind, out))
 }

--- a/tests/testthat/test-optimal-topic.R
+++ b/tests/testthat/test-optimal-topic.R
@@ -1,10 +1,10 @@
 # Characterization tests for optimal_topic(): the C++ core must agree with the
-# naive per-document reference implementation (helper-reference.R) that mirrors
-# the current semantics verbatim, including the round(cum * 1e4) truncation and
-# the lower-tail chi-square p-value documented in AUDIT.md.
+# naive per-document references (helper-reference.R) — the calibrated Test 1 of
+# Eq. (8) for the "sequential"/"min" rules and the frozen pre-0.9.9 pipeline
+# for the deprecated "legacy" rule.
 
 # Row-wise word proportions as a weighted quanteda dfm and as the plain dense
-# matrix the reference implementation consumes.
+# matrix the reference implementations consume.
 optop_wprop_fixture <- function(fx) {
   wdfm <- quanteda::dfm_weight(quanteda::as.dfm(fx$counts), scheme = "prop")
   W_prop <- sweep(fx$counts, 1, rowSums(fx$counts), "/")
@@ -17,21 +17,80 @@ run_optimal_topic <- function(...) {
   suppressMessages(optimal_topic(..., do_plot = FALSE))
 }
 
-test_that("optimal_topic() matches the naive reference", {
+expect_matches_reference <- function(got, ref, info = NULL) {
+  expect_s3_class(got, "data.table")
+  expect_identical(names(got), c("topic", "OpTop", "df", "pval"))
+  expect_equal(got$topic, ref$topic, info = info)
+  expect_equal(got$OpTop, ref$OpTop, tolerance = 1e-10, info = info)
+  expect_equal(got$df, ref$df, info = info)
+  expect_equal(got$pval, ref$pval, tolerance = 1e-10, info = info)
+}
+
+test_that("optimal_topic() matches the naive Eq. (8) reference", {
   fx <- optop_test_fixture()
   wp <- optop_wprop_fixture(fx)
 
-  for (q in c(0.80, 0.95)) {
+  for (q in c(0.95, 0.80)) {
     got <- run_optimal_topic(fx$models, wp$wdfm, q = q)
     ref <- ref_optimal_topic(fx$models, wp$W_prop, q = q)
-
-    info <- sprintf("q=%.2f", q)
-    expect_s3_class(got, "data.table")
-    expect_identical(names(got), c("topic", "OpTop", "pval"))
-    expect_equal(got$topic, ref$topic, info = info)
-    expect_equal(got$OpTop, ref$OpTop, tolerance = 1e-10, info = info)
-    expect_equal(got$pval, ref$pval, tolerance = 1e-10, info = info)
+    expect_matches_reference(got, ref, info = sprintf("q=%.2f", q))
   }
+})
+
+test_that("the returned table does not depend on the selection rule", {
+  fx <- optop_test_fixture()
+  wp <- optop_wprop_fixture(fx)
+
+  got_seq <- run_optimal_topic(fx$models, wp$wdfm)
+  got_min <- run_optimal_topic(fx$models, wp$wdfm, selection = "min")
+  expect_identical(got_seq, got_min)
+})
+
+test_that("selection = \"legacy\" reproduces the pre-0.9.9 pipeline and warns", {
+  fx <- optop_test_fixture()
+  wp <- optop_wprop_fixture(fx)
+
+  expect_warning(
+    got <- run_optimal_topic(fx$models, wp$wdfm, q = 0.80,
+                             selection = "legacy"),
+    class = "lifecycle_warning_deprecated"
+  )
+  ref <- ref_optimal_topic_legacy(fx$models, wp$W_prop, q = 0.80)
+  expect_matches_reference(got, ref)
+})
+
+test_that("the selection rules pick the expected K", {
+  fx <- optop_test_fixture()
+  wp <- optop_wprop_fixture(fx)
+  ref <- ref_optimal_topic(fx$models, wp$W_prop, q = 0.95)
+
+  # sequential: smallest K the test fails to reject
+  seq_pick <- ref$topic[ref$pval > 0.05][1]
+  expect_false(is.na(seq_pick))
+  expect_message(
+    optimal_topic(fx$models, wp$wdfm, do_plot = FALSE, verbose = TRUE),
+    sprintf("Optimal model has %d topics", seq_pick)
+  )
+
+  # min: global minimum of the standardized statistic
+  min_pick <- ref$topic[which.min(ref$OpTop)]
+  expect_message(
+    optimal_topic(fx$models, wp$wdfm, selection = "min",
+                  do_plot = FALSE, verbose = TRUE),
+    sprintf("Optimal model has %d topics", min_pick)
+  )
+
+  # alpha = 1 makes 'pval > alpha' unsatisfiable: the sequential rule must
+  # warn and fall back to the global minimum
+  expect_message(
+    optimal_topic(fx$models, wp$wdfm, alpha = 1, do_plot = FALSE),
+    "falling back to the global minimum"
+  )
+  expect_message(
+    optimal_topic(fx$models, wp$wdfm, alpha = 1, do_plot = FALSE,
+                  verbose = TRUE),
+    sprintf("Optimal model has %d topics", min_pick)
+  )
 })
 
 test_that("documents missing from the models are dropped, order preserved", {
@@ -43,7 +102,7 @@ test_that("documents missing from the models are dropped, order preserved", {
                                      scheme = "prop")
 
   got <- run_optimal_topic(fx$models, wdfm_extra)
-  ref <- ref_optimal_topic(fx$models, wp$W_prop)
+  ref <- ref_optimal_topic(fx$models, wp$W_prop, q = 0.95)
 
   expect_equal(got$OpTop, ref$OpTop, tolerance = 1e-10)
   expect_equal(got$pval, ref$pval, tolerance = 1e-10)
@@ -59,7 +118,7 @@ test_that("optimal_topic() is invariant to document order in the dfm", {
                                     scheme = "prop")
 
   got <- run_optimal_topic(fx$models, wdfm_perm)
-  ref <- ref_optimal_topic(fx$models, wp$W_prop)
+  ref <- ref_optimal_topic(fx$models, wp$W_prop, q = 0.95)
 
   expect_equal(got$OpTop, ref$OpTop, tolerance = 1e-10)
   expect_equal(got$pval, ref$pval, tolerance = 1e-10)
@@ -105,4 +164,6 @@ test_that("optimal_topic() validates its inputs", {
                "q must be a numeric")
   expect_error(optimal_topic(fx$models, wp$wdfm, alpha = "a"),
                "alpha must be a numeric")
+  expect_error(optimal_topic(fx$models, wp$wdfm, selection = "typo"),
+               "should be one of")
 })


### PR DESCRIPTION
Aligns the implementation with Test 1 (Equation 8) of Lewis and Grossetti (2022, JMLR 23(58)). **This PR changes numerical results.**

## What the code did vs. what the paper says

| | pre-0.9.9 code | paper (Eq. 8 / footnote 5) |
|---|---|---|
| Per-document scaling | `P_j` | `P_j + 1` (number of bins) |
| Distribution | `df = 1` on the standardized statistic | `df = sum_j P_j` on the raw sum |
| Tail | lower | upper (adequacy = unable to reject) |
| Selection | first `pval <= alpha` (lower tail) | global minimum of standardized OpTop |
| Cutoff | `round(cum*1e4) > q`, crossing word collapsed, `q = 0.80` | exact comparison, crossing word kept, collapsed mass strictly < `I^K = 0.05` (`q = 0.95`) |

## Changes

- C++ core returns the raw statistic and its df; standardization and p-values live in R.
- `selection = c("sequential", "min", "legacy")`: sequential adequacy scan (default, warned global-minimum fallback), the paper's global-minimum rule, and the frozen pre-0.9.9 pipeline.
- `legacy` is deprecated at birth (lifecycle warning) and verified **bit-identical to v0.9.8** (max delta ~1e-16 on a 2000x8000 corpus); removal before v1.0.0.
- Returned table gains a `df` column; docs carry the calibration caveat (with huge df, chi-square p-values saturate near 0/1 — the standardized curve's minimum then carries the information, hence the paper's min rule).
- Naive reference implementations for both pipelines; 298 tests green; local `R CMD check` 0/0/0.

Full details in NEWS.md and AUDIT.md.