### PR TITLE
Release 0.14.3: 64-bit Armadillo indexing for very large corpora

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: OpTop
 Type: Package
 Title: Optimal Topic Selection and Goodness-of-Fit for Topic Models
-Version: 0.14.2
+Version: 0.14.3
 Authors@R: c( 
     person("Francesco", "Grossetti", email = "francesco.grossetti@unibocconi.it", 
     role = c("cre", "aut", "cph"), comment = c(ORCID = "0000-0002-5130-7745")), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,30 @@
+# OpTop 0.14.3
+
+A large-corpus indexing release.
+
+### Fixes
+
+* **64-bit Armadillo indexing** (`-DARMA_64BIT_WORD` in both Makevars): the
+  compiled cores receive the document-term matrix as an Armadillo sparse
+  matrix, whose constructor requires the documents-by-features shape to be
+  addressable by its integer index type. With the previous 32-bit indices any
+  corpus whose `J * W` exceeded `2^31 - 1` cells failed at the boundary with
+  `SpMat::init(): requested size is too large`, regardless of how sparse the
+  matrix actually was (observed on 3.1 million documents by 57,440 features).
+  All cores now compile with 64-bit indices, which also protects the dense
+  document-topic matrices whose element count passes `2^31` at extreme scale.
+
+### Known limits at very large scale
+
+* A single `dgCMatrix` (and hence a single quanteda dfm) holds at most
+  `2^31 - 1` nonzero entries, an R container limit no compiler flag lifts;
+  corpora beyond it need document sharding, planned for the next minor
+  release together with a zero-copy sparse boundary and a sparse partition
+  representation. Until then `optimal_topic()` is the supported entry point
+  at multi-million-document scale: `optop_make_partition()` and the index
+  family still materialize dense documents-by-features objects internally
+  and remain intended for corpora of moderate size.
+
 # OpTop 0.14.2
 
 A documentation release. The README now states the per-platform build

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![lifecycle](https://lifecycle.r-lib.org/articles/figures/lifecycle-experimental.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 [![R-CMD-check](https://github.com/contefranz/OpTop/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/contefranz/OpTop/actions/workflows/R-CMD-check.yaml)
 [![codecov](https://codecov.io/gh/contefranz/OpTop/graph/badge.svg)](https://app.codecov.io/gh/contefranz/OpTop)
-[![release](https://img.shields.io/badge/release-v0.14.2-blue.svg)](https://github.com/contefranz/OpTop/releases/tag/v0.14.2)
+[![release](https://img.shields.io/badge/release-v0.14.3-blue.svg)](https://github.com/contefranz/OpTop/releases/tag/v0.14.3)
 [![license](https://img.shields.io/badge/license-GPL--3-blue.svg)](https://en.wikipedia.org/wiki/GNU_General_Public_License)
 
 # OpTop

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,2 +1,5 @@
+# 64-bit Armadillo indices: sparse and dense containers whose shape exceeds
+# 2^31 - 1 addressable cells (large J x W corpora) need a 64-bit uword
+PKG_CPPFLAGS = -DARMA_64BIT_WORD
 PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
 PKG_LIBS = $(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,2 +1,5 @@
+# 64-bit Armadillo indices: sparse and dense containers whose shape exceeds
+# 2^31 - 1 addressable cells (large J x W corpora) need a 64-bit uword
+PKG_CPPFLAGS = -DARMA_64BIT_WORD
 PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
 PKG_LIBS = $(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)

--- a/tests/testthat/test-large-shape.R
+++ b/tests/testthat/test-large-shape.R
@@ -1,0 +1,27 @@
+# The compiled cores receive the dfm as an Armadillo sparse matrix, whose
+# constructor requires n_rows * n_cols to fit the index type uword. The
+# package compiles with ARMA_64BIT_WORD (src/Makevars), so shapes beyond
+# 2^31 - 1 cells must cross the boundary; under 32-bit indices the call
+# below dies with "SpMat::init(): requested size is too large". The test is
+# cheap by construction: the shape is huge (5e9 cells) but the work is
+# O(nnz + J) because only one word column is evaluated.
+
+test_that("the sparse boundary accepts shapes beyond 32-bit indexing", {
+  J <- 100000L
+  W <- 50000L   # J * W = 5e9 > 2^32 - 1: fails without ARMA_64BIT_WORD
+  set.seed(99)
+  nnz <- 1000L
+  N <- Matrix::sparseMatrix(i = sample.int(J, nnz, replace = TRUE),
+                            j = sample.int(W, nnz, replace = TRUE),
+                            x = stats::rpois(nnz, 3) + 1,
+                            dims = c(J, W))
+  N <- methods::as(N, "CsparseMatrix")
+  out <- optop_index_word_core(
+    matrix(0, 0, 0), N, 0L, 1L,
+    as.numeric(Matrix::rowSums(N)), 0.5, 1e-12,
+    FALSE, TRUE,
+    TRUE, FALSE, FALSE, 1L
+  )
+  expect_identical(dim(out), c(1L, 6L))
+  expect_true(all(is.finite(out)))
+})


### PR DESCRIPTION
A targeted patch release that unblocks multi-million-document corpora.

The compiled cores receive the document-term matrix as an Armadillo sparse
matrix, whose constructor requires the documents-by-features shape to be
addressable by its integer index type. With the default 32-bit indices any
corpus whose J x W exceeded 2^31 - 1 cells failed at the boundary with
`SpMat::init(): requested size is too large`, regardless of how sparse the
matrix actually was; the failure was observed on 3.1 million documents by
57,440 features. Both Makevars now define `ARMA_64BIT_WORD`, which lifts
the sparse shape check and also protects the dense document-topic matrices
whose element count passes 2^31 at extreme scale.

Verification: a permanent boundary regression test crosses a 5e9-cell
sparse shape at O(nnz + J) cost, so the flag cannot silently regress;
`optimal_topic()` was run end to end on a synthetic corpus above the old
cap (1.55M documents x 2,800 features, 172 s on 8 threads); the full test
suite passes and `R CMD check` is clean with 0 errors, 0 warnings, 0 notes.

NEWS documents the limits that remain by design until the planned scale
release: a single dfm holds at most 2^31 - 1 nonzero entries (an R
container limit no compiler flag lifts, to be addressed by document
sharding), and the harmonized partition and the index family still
materialize dense documents-by-features objects internally and remain
intended for corpora of moderate size.